### PR TITLE
borderSize + image + rounded features

### DIFF
--- a/VanillaQR.js
+++ b/VanillaQR.js
@@ -12,47 +12,29 @@ function VanillaQR ( customize ) {
 
     scope.revision = 3;
 
-    //canvas output types
-    scope.imageTypes = {
-        "bmp"    : "image/bmp",
-        "gif"    : "image/gif",
-        "jpeg"   : "image/jpeg",
-        "jpg"    : "image/jpg",
-        "png"    : "image/png",
-        "svg+xml": "image/svg+xml",
-        "tiff"   : "image/tiff",
-        "webp"   : "image/webp",
-        "x-icon" : "image/x-icon"
-    };
-
-    //toTable use will default if no canvas support
-    scope.toTable = customize.toTable;
-
-    //qr active domElement
-    scope.domElement = (scope.toTable) ?
-        document.createElement("div"):
-        document.createElement("canvas");
+    scope.domElement = document.createElement('canvas');
+    scope.qrc = scope.domElement.getContext('2d');
+    scope.domElement.style.verticalAlign = 'top';
+    scope.domElement.style.width = '100%';
 
     //QR url
     scope.url = customize.url || "";
 
     //Canvas and qr width and height
-    scope.size  = (customize.size  || 280);
-
-    //QR context
-    scope.qrc = false;
+    scope.size = customize.size || 280;
 
     //QR colors
-    scope.colorLight = customize.colorLight || '#fff';
+    scope.colorLight = customize.colorLight;
     scope.colorDark = customize.colorDark || "#000";
 
-    //Correction level
+    //Correction level (1-4)
     scope.ecclevel = customize.ecclevel || 1;
 
     //Border related
-    scope.noBorder = customize.noBorder;
-    scope.borderSize = customize.borderSize || 4;
+    scope.borderSize = customize.borderSize || 0;
 
+    //Rounded
+    scope.rounded = customize.rounded;
 
     /********************PRIVATES********************/
 
@@ -73,7 +55,6 @@ function VanillaQR ( customize ) {
 	var neccblk2;
 	var datablkw;
 	var eccblkwid;
-
 
     /********************QR Creator API********************/
 
@@ -114,7 +95,7 @@ function VanillaQR ( customize ) {
             setmask(x - j, y - 1);
             setmask(x + j, y + 1);
         }
-    }
+    };
 
     //Bit shift modnn
     var modnn = function(x) {
@@ -268,18 +249,19 @@ function VanillaQR ( customize ) {
                 runsbad += VanillaQR.N1 + rlens[i] - 5;
         // BwBBBwB as in finder
         for (i = 3; i < length - 1; i += 2)
-            if (rlens[i - 2] == rlens[i + 2]
-                && rlens[i + 2] == rlens[i - 1]
-                && rlens[i - 1] == rlens[i + 1]
-                && rlens[i - 1] * 3 == rlens[i]
-                // white around the black pattern? Not part of spec
-                && (rlens[i - 3] == 0 // beginning
-                    || i + 3 > length  // end
-                    || rlens[i - 3] * 3 >= rlens[i] * 4 || rlens[i + 3] * 3 >= rlens[i] * 4)
-               )
-                runsbad += VanillaQR.N3;
+            if (
+                rlens[i - 2] == rlens[i + 2] &&
+                rlens[i + 2] == rlens[i - 1] &&
+                rlens[i - 1] == rlens[i + 1] &&
+                rlens[i - 1] * 3 == rlens[i] &&
+                (
+                    rlens[i - 3] == 0 || // beginning
+                    i + 3 > length    || // end
+                    rlens[i - 3] * 3 >= rlens[i] * 4 || rlens[i + 3] * 3 >= rlens[i] * 4
+                )
+            )
+            runsbad += VanillaQR.N3;
         return runsbad;
-
     };
 
     // Calculate how bad the masked image is - blocks, imbalance, runs, or finders.
@@ -292,11 +274,11 @@ function VanillaQR ( customize ) {
         // blocks of same color.
         for (y = 0; y < width - 1; y++) {
             for (x = 0; x < width - 1; x++) {
-                if ((qrframe[x + width * y] && qrframe[(x + 1) + width * y]
-                     && qrframe[x + width * (y + 1)] && qrframe[(x + 1) + width * (y + 1)]) // all black
-                    || !(qrframe[x + width * y] || qrframe[(x + 1) + width * y]
-                         || qrframe[x + width * (y + 1)] || qrframe[(x + 1) + width * (y + 1)])) // all white
-                    thisbad += VanillaQR.N2;
+                if (
+                    (qrframe[x + width * y] && qrframe[(x + 1) + width * y] && qrframe[x + width * (y + 1)] && qrframe[(x + 1) + width * (y + 1)]) || // all black
+                    !(qrframe[x + width * y] || qrframe[(x + 1) + width * y] || qrframe[x + width * (y + 1)] || qrframe[(x + 1) + width * (y + 1)])    // all white
+                )
+                thisbad += VanillaQR.N2;
             }
         }
 
@@ -324,8 +306,8 @@ function VanillaQR ( customize ) {
         var count = 0;
         big += big << 2;
         big <<= 1;
-        while (big > width * width)
-            big -= width * width, count++;
+        while (big > width * width) {
+            big -= width * width; count++;}
         thisbad += count * VanillaQR.N4;
 
         // Y runs
@@ -552,8 +534,9 @@ function VanillaQR ( customize ) {
         for (i = 0; i < eccblkwid; i++) {
             genpoly[i + 1] = 1;
             for (j = i; j > 0; j--)
-                genpoly[j] = genpoly[j]
-                ? genpoly[j - 1] ^ gexp[modnn(glog[genpoly[j]] + i)] : genpoly[j - 1];
+                genpoly[j] = genpoly[j] ?
+                    genpoly[j - 1] ^ gexp[modnn(glog[genpoly[j]] + i)] :
+                    genpoly[j - 1];
             genpoly[0] = gexp[modnn(glog[genpoly[0]] + i)];
         }
         for (i = 0; i <= eccblkwid; i++)
@@ -686,19 +669,12 @@ function VanillaQR ( customize ) {
     scope.init = function() {
 
         ecclevel = scope.ecclevel;
-        var qf = scope.genframe(scope.url);
-
-        if(scope.toTable) {
-
-            scope.tableWrite(qf, width);
-
-        } else {
-
-            scope.canvasWrite(qf, width);
-
-        }
+        scope.canvasWrite(scope.genframe(scope.url), width);
 
     };
+
+    //Image
+    scope.loadImage(customize.image);
 
     //Auto initialize
     scope.init();
@@ -708,211 +684,102 @@ function VanillaQR ( customize ) {
 //Get canvas 2D Context
 VanillaQR.prototype = {
 
+    loadImage : function(src)
+    {
+        var scope = this;
+        if (src) {
+
+            scope.image = new Image();
+            scope.image.onload = () => scope.init();
+            scope.image.src = src;
+
+        } else if (scope.image) {
+
+            scope.image = null;
+            scope.init();
+
+        }
+    },
+
     //Canvas create
     canvasWrite: function(qf, width) {
 
         var scope = this;
 
-        //Get context and proceed if it is allowed
-        if(!scope.qrc) {
-
-            scope.qrc = scope.getContext(scope.domElement);
-
-            //No canvas support default to Table
-            if(!scope.qrc) {
-                scope.toTable = true;
-                scope.domElement = document.createElement("div");
-                scope.tableWrite(qf, width);
-                return;
-            }
-
-        }
-
         //Setup canvas context
         var size = scope.size;
         var qrc = scope.qrc;
+        var rndd = scope.rounded && qrc.roundRect && true;
+        var px = Math.round(size / width);
+        var offset = scope.borderSize;
+        var i, j, k, l;
 
-        qrc.lineWidth=1;
-
-        var px = size;
-        px /= width + 10;
-        px=Math.round(px - 0.5);
-
-        var offset = 4;
-
-        if (scope.noBorder) {
-            qrc.canvas.width = qrc.canvas.height = px * width;
-            offset = 0;
-        }
-        else {
-            qrc.canvas.width = qrc.canvas.height = size;
-        }
+        qrc.lineWidth = 1;
+        qrc.canvas.width = qrc.canvas.height = px * (width + offset * 2);
 
         //Fill canvas with set colors
         qrc.clearRect( 0, 0, size, size );
-        qrc.fillStyle = scope.colorLight;
-        qrc.fillRect(0, 0, px*(width+8), px*(width+8));
+        if (scope.colorLight) {
+            qrc.fillStyle = scope.colorLight;
+            qrc.fillRect(0, 0, px*(width+8), px*(width+8));
+        }
         qrc.fillStyle = scope.colorDark;
 
-        //Write boxes per row
-        for( var i = 0; i < width; i++ ) {
+        if (scope.image) {
 
-            for( var j = 0; j < width; j++ ) {
+            k  =  Math.ceil(width * 0.25);
+            k += (width - k) % 2;
+            l  = (width / 2) - (k / 2);
+
+            for ( i = 0; i < width; ++i ) {
+                for ( j = 0; j < width; ++j ) {
+                    if (i >= l && i < (l + k) && j >= l && j < (l + k))
+                        qf[j*width+i] = 0;
+                }
+            }
+            qrc.drawImage(
+
+                scope.image,
+                (l + offset + 0.5) * px,
+                (l + offset + 0.5) * px,
+                (k - 1) * px,
+                (k - 1) * px
+
+            );
+        }
+
+        //Write boxes per row
+        for ( i = 0; i < width; ++i ) {
+            for ( j = 0; j < width; ++j ) {
                 if( qf[j*width+i] ) {
-                    qrc.fillRect(px*(offset+i),px*(offset+j),px,px);
+                    if (rndd) {
+
+                        k = [
+                            i && qf[j*width+(i - 1)],
+                            j && qf[(j - 1)*width+i],
+                            i < (width - 1) && qf[j*width+(i + 1)],
+                            j < (width - 1) && qf[(j + 1)*width+i]
+                        ];
+
+                        qrc.beginPath();
+                        qrc.roundRect(px*(offset+i),px*(offset+j),px,px, [
+
+                            (k[0] || k[1]) ? 0 : 8,
+                            (k[1] || k[2]) ? 0 : 8,
+                            (k[2] || k[3]) ? 0 : 8,
+                            (k[3] || k[0]) ? 0 : 8
+
+                        ]);
+                        qrc.fill();
+
+                    } else {
+
+                        qrc.fillRect(px*(offset+i),px*(offset+j),px,px);
+
+                    }
                 }
-             }
-
-         }
-
-    },
-
-    //Table write qr code
-    tableWrite: function(qf, width) {
-
-        var scope = this;
-
-        //Table style
-        var collapseStyle = "border:0;border-collapse:collapse;";
-        var tdWidth = Math.round((this.size / width) - 3.5) + "px";
-        var borderWidth = width + ( ( scope.noBorder ) ? 0 : ( scope.borderSize * 2 ) );
-        var sideBorderWidth = scope.borderSize;
-        var tdStyle = "width:" + tdWidth + ";height:" + tdWidth + ";";
-
-        var colorLight = scope.colorLight;
-        var colorDark = scope.colorDark;
-
-        //Table elements
-        var table = document.createElement("table");
-        table.style.cssText = collapseStyle;
-
-        var tr = document.createElement("tr");
-        var td = document.createElement("td");
-
-        //Cloning and creating table Elements
-        var cloneTD = function() { return td.cloneNode(); };
-
-        var createTDDark = function() {
-            var elem = cloneTD();
-            elem.style.cssText = tdStyle + "background:" + colorDark;
-            return elem;
-        };
-
-        var createTDLight = function() {
-            var elem = cloneTD();
-            elem.style.cssText = tdStyle + "background:" + colorLight;
-            return elem;
-        }
-
-
-        //Regular borders appending
-        var appendBorders = function( table ) {
-
-            var insertNode = table.firstChild;
-
-            for( var i = 0; i < scope.borderSize; i ++ ) {
-
-                var row = tr.cloneNode();
-
-                for( var t = 0; t < borderWidth; t++ ) {
-                    var lightTD = createTDLight();
-                    row.appendChild(lightTD);
-                }
-
-                table.appendChild( row );
-                table.insertBefore( row.cloneNode( true ), insertNode );
-
             }
-
         }
-
-
-        //Create side border
-        var appendSideBorders = function( row ) {
-
-            var insertNode = row.firstChild;
-
-            for( var i = 0; i < sideBorderWidth; i ++ ) {
-
-                row.insertBefore( createTDLight(), insertNode );
-
-                row.appendChild(createTDLight());
-
-            }
-
-        };
-
-        //Write boxes per row
-        for( var i = 0; i < width; i++ ) {
-
-            var currentRow = tr.cloneNode();
-            table.appendChild(currentRow);
-
-            for( var j = 0; j < width; j++ ) {
-
-                //Is a dark color
-                if( qf[ (i*width) + j ] === 1 ) {
-                    var darkTd = createTDDark();
-                    currentRow.appendChild(darkTd);
-                }
-
-                //Light color
-                else {
-                    var lightTD = createTDLight();
-                    currentRow.appendChild(lightTD);
-                }
-
-            }
-
-            if( !scope.noBorder ) {
-
-                appendSideBorders(currentRow);
-
-            }
-
-        }
-
-        if( !scope.noBorder ) {
-
-            appendBorders( table );
-
-        }
-
-         scope.domElement.innerHTML = "";
-         scope.domElement.appendChild(table);
-
-    },
-
-    //get domElement 2D  Context
-    getContext: function(domElement) {
-
-        //try to get 2d context error
-        if(!(domElement.getContext && domElement.getContext('2d'))) {
-
-            console.log("Browser does not have 2d Canvas support");
-            return false;
-
-        }
-
-        return domElement.getContext('2d');
-
-    },
-
-    //QR frame to image type
-    toImage: function(type) {
-
-        if(!this.qrc) {return;}
-
-        //Check image output type
-        var dataType = this.imageTypes[type];
-        if(!dataType) {
-            throw new Error(type + " is not a valid image type ");
-        }
-
-        //create image with src of QR code
-    	var image = new Image;
-    	image.src = this.domElement.toDataURL(dataType);
-    	return image;
 
     }
 
@@ -922,9 +789,9 @@ VanillaQR.prototype = {
 // Private variables
 // alignment pattern
 VanillaQR.adelta = [
-  0, 11, 15, 19, 23, 27, 31, // force 1 pat
-  16, 18, 20, 22, 24, 26, 28, 20, 22, 24, 24, 26, 28, 28, 22, 24, 24,
-  26, 26, 28, 28, 24, 24, 26, 26, 26, 28, 28, 24, 26, 26, 26, 28, 28
+    0, 11, 15, 19, 23, 27, 31, // force 1 pat
+    16, 18, 20, 22, 24, 26, 28, 20, 22, 24, 24, 26, 28, 28, 22, 24, 24,
+    26, 26, 28, 28, 24, 24, 26, 26, 26, 28, 28, 24, 26, 26, 26, 28, 28
 ];
 
 // version block


### PR DESCRIPTION
Been using this plugin for a while now, and have make several modifications that have been extremely useful. I've tried my best to keep the formatting the same as the original.

- Added borderSize for canvas border width, defaults to 0. Removed noBorder; 
- Added image customization argument to load a image resource in the center of the qrcode; 
- Added rounded customization argument to utilize roundRect canvas function for rounding isolated blocks; 
- Allow secondary color to be optional for transparent backgrounds;
- Removed table fallback;
- Removed image export;
- Restructured code so jshint reports less issues;
-------
```
let code = new VanillaQR(
{
	url : 'https://chuckfairy.com/',
	ecclevel : 3,
	borderSize : 2,
	size : 1000,
	image : 'https://avatars2.githubusercontent.com/u/7469548',
	rounded : true
});
```